### PR TITLE
Catch 404 not found as a real error

### DIFF
--- a/lib/MojoX/JSON/RPC/Client.pm
+++ b/lib/MojoX/JSON/RPC/Client.pm
@@ -108,7 +108,7 @@ sub _process_result {
     }
 
     # Check if RPC call is succesfull
-    if ( !( $tx_res->is_status_class(200) || $tx_res->is_status_class(400) ) )
+    if ( !( $tx_res->is_status_class(200) ) )
     {
         return;
     }


### PR DESCRIPTION
I don't understand why this if has a special case for status_class(400)..
It means that a 404 error becomes a empty response instead of a real error.
